### PR TITLE
Add link to API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@ open-hmis-data-warehouse
 Contains wiki documentation, and issue tracker for the ServingLynk Open HMIS Data Warehouse project.
 
 For discussion of the HMIS API, please see the [HMIS API Discussion Group](https://groups.google.com/forum/#!forum/hmis-api).  Please note that that discussion group is vendor-neutral: it is for discussing requests, responses, and endpoints, not specific products or business goals.
+
+For full API documentation, please see [the reference](https://anypoint.mulesoft.com/apiplatform/apis/#/portals/organizations/1d2d1eb1-46af-4ee8-aa04-bd79ed2764a3/apis/62269/versions/64666).


### PR DESCRIPTION
As discussed [on the list](https://groups.google.com/forum/#!topic/hmis-api/P88k1h4gTLo), link to the full API reference from this documentation.